### PR TITLE
make loop a singleton

### DIFF
--- a/miserable/config.py
+++ b/miserable/config.py
@@ -22,7 +22,7 @@ import copy
 import json
 import argparse
 import sys
-from miserable.utils import *
+from miserable.utils.net import *
 
 
 class ConfigManager(object):

--- a/miserable/config.py
+++ b/miserable/config.py
@@ -22,7 +22,7 @@ import copy
 import json
 import argparse
 import sys
-from miserable.utils.net import *
+from miserable.utils import *
 
 
 class ConfigManager(object):

--- a/miserable/loop.py
+++ b/miserable/loop.py
@@ -21,8 +21,10 @@ from __future__ import absolute_import, division, print_function, \
 import selectors
 import time
 
+from miserable.utils import singleton
 
-class MainLoop(object):
+
+class MainLoop(object, metaclass=singleton):
 
     EVENT_READ = selectors.EVENT_READ
     EVENT_WRITE = selectors.EVENT_WRITE

--- a/miserable/loop.py
+++ b/miserable/loop.py
@@ -30,17 +30,14 @@ class MainLoop(object):
 
     def __init__(self):
         self._selector = selectors.DefaultSelector()
-        self._files = set()
         self._timeouts = {}
         self._running = False
 
     def register(self, fileobj, events, func):
         self._selector.register(fileobj, events, func)
-        self._files.add(fileobj)
 
     def unregister(self, fileobj):
         self._selector.unregister(fileobj)
-        self._files.remove(fileobj)
 
     def modify(self, fileobj, events, func):
         self._selector.modify(fileobj, events, func)

--- a/miserable/utils.py
+++ b/miserable/utils.py
@@ -165,3 +165,24 @@ def ignore_inprogress_exception(f):
             if not exception_inprogress(e):
                 raise e
     return wrapper
+
+
+class Singleton(type):
+    """copy from http://stackoverflow.com/questions/6760685/creating-a-singleton-in-python
+
+    usage:
+
+    #Python2
+    class MyClass(BaseClass):
+        __metaclass__ = Singleton
+
+    #Python3
+    class MyClass(BaseClass, metaclass=Singleton):
+        pass
+    """
+    _instances = {}
+
+    def __call__(cls, *args, **kwargs):
+        if cls not in cls._instances:
+            cls._instances[cls] = super(Singleton, cls).__call__(*args, **kwargs)
+        return cls._instances[cls]


### PR DESCRIPTION
把loop变成单例。
删除了 `self._files` 既然每个register的fileobj都保存了对应的func, 再用 `self._files` 好像没有必要？
